### PR TITLE
Added automatic discovery of drush folder

### DIFF
--- a/templates/platform/build.sh
+++ b/templates/platform/build.sh
@@ -1,1 +1,11 @@
+#!/bin/bash
+
 drush situs-build --root=htdocs --make-file=./platform.make --git-check --git-check-ignore-regex=/global/,/contrib/,/libraries/
+
+if pushd "htdocs/sites/all" > /dev/null; then
+  if [ ! -L "drush" ]; then
+    ln -s ../../../drush .
+    echo "Symlink created for drush."
+  fi
+  popd > /dev/null;
+fi


### PR DESCRIPTION
Use the build in drush discovery path to include the drush folder instead of the custom script.
Discovery will work when inside the htdocs folder and can be used to centralize the inclusion of site aliases, commands and common drush settings.