### PR TITLE
Symlink drush folder into sites/all

### DIFF
--- a/templates/platform/build.sh
+++ b/templates/platform/build.sh
@@ -1,1 +1,9 @@
 drush situs-build --root=htdocs --make-file=./platform.make --git-check --git-check-ignore-regex=/global/,/contrib/,/libraries/
+
+if pushd "htdocs/sites/all" > /dev/null; then
+  if [ ! -L "drush" ]; then
+    ln -s ../../../drush .
+    echo "Symlink created for drush."
+  fi
+  popd > /dev/null;
+fi


### PR DESCRIPTION
When building create the symlink for the drush folder.

When executing drush commands for a given site directory the path "sites/all/drush" gets auto-discovered and hence it makes sense to use that for figuring out related commands, configuration and site-aliases.