### PR TITLE
Adding "npm install" to build.sh

### DIFF
--- a/templates/platform/build.sh
+++ b/templates/platform/build.sh
@@ -7,3 +7,8 @@ if pushd "htdocs/sites/all" > /dev/null; then
   fi
   popd > /dev/null;
 fi
+
+if pushd "htdocs/profiles/{{ profile }}/themes/custom/{{ profile }}_theme" > /dev/null; then
+  npm install
+  popd > /dev/null;
+fi


### PR DESCRIPTION
Adding "npm install" to build.sh for the new basetheme package manager