### PR TITLE
Updated drush configuration for new projects

### DIFF
--- a/templates/platform/drush/aliases/aliases.drushrc.php
+++ b/templates/platform/drush/aliases/aliases.drushrc.php
@@ -10,11 +10,50 @@
  * everyone can just overwrite the different settings.
  */
 
-$aliases['loc'] = array(
+$user_home_dir = $_SERVER['HOME'];
+$vagrant_dir = (isset($vagrant_dir)) ? $vagrant_dir : "$user_home_dir/Workspace/parrot";
+$vagrant = [
+  "-p",
+  "2222",
+  "-o",
+  "Compression=yes",
+  "-o",
+  "DSAAuthentication=yes",
+  "-o",
+  "LogLevel=FATAL",
+  "-o",
+  "StrictHostKeyChecking=no",
+  "-o",
+  "UserKnownHostsFile=/dev/null",
+  "-o",
+  "IdentitiesOnly=yes",
+  "-i",
+  "$vagrant_dir/.vagrant/machines/default/virtualbox/private_key",
+  "-o",
+  "ForwardAgent=yes"
+];
+
+$aliases['local'] = array(
+  'uri' => '{{ domain.local }}',
+  'root' => $user_home_dir . '/Sites/{{ domain.local }}/htdocs',
+);
+$aliases['loc'] = [
+  'parent' => '@local',
+];
+$aliases['l'] = [
+  'parent' => '@local',
+];
+$aliases['vagrant'] = [
   'uri' => '{{ domain.local }}',
   'root' => '/vagrant_sites/{{ domain.local }}/htdocs',
   'remote-host' => 'default',
-);
+//  'remote-user' => 'vagrant',
+//  'remote-host' => "127.0.0.1",
+//  'ssh-options' => implode(' ', $vagrant),
+];
+$aliases['v'] = [
+  'parent' => '@vagrant',
+];
 
 $aliases['test'] = array(
   'uri' => '{{ domain.stage }}',

--- a/templates/platform/drush/commands/build.drush.inc
+++ b/templates/platform/drush/commands/build.drush.inc
@@ -119,7 +119,7 @@ function _drush_devify()
 
     // Sanitize database.
     // @see sql_drush_sql_sync_sanitize() to add your sanitize queries.
-    drush_sql_sanitize();
+    #drush_sql_sanitize();
 
     drush_log(dt('Devified!'), 'success');
 }

--- a/templates/platform/drush/drushrc.php
+++ b/templates/platform/drush/drushrc.php
@@ -200,6 +200,7 @@ $options['enable-modules'] = array(
   'field_ui',
   'devel',
   'devel_generate',
+  'stage_file_proxy',
 );
 
 /**


### PR DESCRIPTION
Now new drush projects will by default have site aliases for both local and vagrant setups.
The devify command will no longer request to sanitize the database.
Stage file proxy will now be enabled upon running devify.